### PR TITLE
shut off annotatons for windows+PNG

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -890,9 +890,10 @@ void MolDraw2D::calculateScale(int width, int height,
   // as well.
   while (scale_ > 1e-4) {
     adjustScaleForAtomLabels(highlight_atoms, highlight_radii);
-    adjustScaleForAnnotation(atom_notes_[activeMolIdx_]);
-    adjustScaleForAnnotation(bond_notes_[activeMolIdx_]);
-
+    if((!atom_notes_.empty() || !bond_notes_.empty()) && supportsAnnotations()){
+      adjustScaleForAnnotation(atom_notes_[activeMolIdx_]);
+      adjustScaleForAnnotation(bond_notes_[activeMolIdx_]);
+    }
     double old_scale = scale_;
     scale_ = std::min(double(width) / x_range_, double(height) / y_range_);
     if (fabs(scale_ - old_scale) < 0.1) {
@@ -1434,15 +1435,18 @@ void MolDraw2D::finishMoleculeDraw(const RDKit::ROMol &draw_mol,
     }
   }
   setColour(DrawColour(0.0, 0.0, 0.0));
+  if(!supportsAnnotations() && (!atom_notes_.empty() || !bond_notes_.empty())){
+    BOOST_LOG(rdWarningLog)<<"annotations not currently supported for this MolDraw2D class, they will be ignored."<<std::endl;
+  }
   for(auto atom: draw_mol.atoms()) {
-    if (atom_notes_[activeMolIdx_][atom->getIdx()]) {
+    if (supportsAnnotations() && atom_notes_[activeMolIdx_][atom->getIdx()]) {
       drawAnnotation(atom->getProp<string>("atomNote"),
                      atom_notes_[activeMolIdx_][atom->getIdx()]);
     }
   }
 
   for(auto bond: draw_mol.bonds()) {
-    if (bond_notes_[activeMolIdx_][bond->getIdx()]) {
+    if (supportsAnnotations() && bond_notes_[activeMolIdx_][bond->getIdx()]) {
       drawAnnotation(bond->getProp<string>("bondNote"),
                      bond_notes_[activeMolIdx_][bond->getIdx()]);
     }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -578,6 +578,10 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
   // add R/S and E/Z annotation to atoms and bonds respectively.
   void addStereoAnnotation(const ROMol &mol);
 
+  virtual bool supportsAnnotations() {
+    return true;
+  }
+
  private:
   bool needs_scale_;
   int width_, height_, panel_width_, panel_height_;
@@ -696,7 +700,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
                      const std::vector<int> *highlight_atoms = nullptr,
                      const std::map<int, DrawColour> *highlight_map = nullptr);
   void drawAtomLabel(int atom_num, const DrawColour &draw_colour);
-  void drawAnnotation(const std::string &note,
+  virtual void drawAnnotation(const std::string &note,
                       const std::shared_ptr<StringRect> &note_rect);
   void drawRadicals(const ROMol &mol);
   // find a good starting point for scanning round the annotation

--- a/Code/GraphMol/MolDraw2D/MolDraw2DCairo.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DCairo.h
@@ -77,6 +77,13 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2DCairo : public MolDraw2D {
   // writes the PNG data to a file
   void writeDrawingText(const std::string &fName) const;
 
+#ifdef WIN32
+  bool supportsAnnotations() override {
+     return false;
+  }
+#endif
+
+
  private:
   cairo_t *dp_cr;
 

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -2668,11 +2668,7 @@ void test20Annotate() {
       MolDraw2DCairo drawer(500, 500);
       drawer.drawMolecule(*m1);
       drawer.finishDrawing();
-
-      std::string drawing = drawer.getDrawingText();
-      TEST_ASSERT(drawing.size() > 0);
-      std::ofstream ofs("test20_1.png");
-      ofs.write(drawing.c_str(), drawing.size());
+      drawer.writeDrawingText("test20_1.png");
     }
 #endif
 
@@ -2698,10 +2694,7 @@ void test20Annotate() {
       drawer.drawMolecule(*m1);
       drawer.finishDrawing();
 
-      std::string drawing = drawer.getDrawingText();
-      TEST_ASSERT(drawing.size() > 0);
-      std::ofstream ofs("test20_2.png");
-      ofs.write(drawing.c_str(), drawing.size());
+      drawer.writeDrawingText("test20_2.png");
     }
 #endif
     MolDraw2DSVG drawer(500, 500);
@@ -2729,11 +2722,7 @@ void test20Annotate() {
       drawer.drawOptions().addStereoAnnotation = true;
       drawer.drawMolecule(*m1);
       drawer.finishDrawing();
-
-      std::string drawing = drawer.getDrawingText();
-      TEST_ASSERT(drawing.size() > 0);
-      std::ofstream ofs("test20_3.png");
-      ofs.write(drawing.c_str(), drawing.size());
+      drawer.writeDrawingText("test20_3.png");
     }
 #endif
     MolDraw2DSVG drawer(500, 500);


### PR DESCRIPTION
Until we can figure out the cross-platform font handling a bit better, the annotations need to be disabled when using cairo on windows.